### PR TITLE
Repeatable tasks branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ debian/files
 debian/debhelper-build-stamp
 debian/rclone-browser*
 
+/bs0.cmd

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,12 +31,14 @@ set(MOC
   stream_widget.h
   preferences_dialog.h
   icon_cache.h
+  ListOfJobOptions.h
   item_model.h
 )
 
 set(OTHER
   pch.h
   utils.h
+  JobOptions.h
 )
 
 set(SOURCE
@@ -54,6 +56,8 @@ set(SOURCE
   icon_cache.cpp
   item_model.cpp
   utils.cpp
+  JobOptions.cpp
+  ListOfJobOptions.cpp
 )
 
 if(WIN32)

--- a/src/JobOptions.cpp
+++ b/src/JobOptions.cpp
@@ -1,0 +1,185 @@
+#include "JobOptions.h"
+#include <qexception.h>
+#include <qdebug.h>
+#include <qlogging.h>
+#ifdef _WIN32
+#pragma warning(disable:4505)
+#endif
+JobOptions::JobOptions(bool isDownload) : JobOptions()
+{
+	setJobType(isDownload);
+	uniqueId = QUuid::createUuid();
+}
+
+JobOptions::JobOptions():
+	jobType(UnknownJobType), operation(UnknownOp), dryRun(false), sync(false), 
+    syncTiming(UnknownTiming), skipNewer(false), skipExisting(false), 
+    compare(false), compareOption(), verbose(false), sameFilesystem(false),
+	dontUpdateModified(false), maxDepth(0), deleteExcluded(false), isFolder(false)
+{
+}
+
+const qint32 JobOptions::classVersion = 3;
+
+
+JobOptions::~JobOptions()
+{
+}
+
+/*
+ * Turn the options held here into a string list for 
+ * use in the rclone command.  
+ * 
+ * This logic was originally in transfer_dialog.cpp.
+ * 
+ * This needs to change whenever e.g. new options are 
+ * added to the dialog.
+ */
+QStringList JobOptions::getOptions() const
+{
+	QStringList list;
+
+	if (operation == Copy)
+	{
+		list << "copy";
+	}
+	else if (operation == Move)
+	{
+		list << "move";
+	}
+	else if (operation == Sync)
+	{
+		list << "sync";
+	}
+
+	if (dryRun)
+	{
+		list << "--dry-run";
+	}
+
+	if (sync)
+	{
+		switch (syncTiming)
+		{
+		case During:
+			list << "--delete-during";
+			break;
+		case After:
+			list << "--delete-after";
+			break;
+		case Before:
+			list << "--delete-before";
+			break;
+		default: 
+			break;;
+		}
+	}
+
+	if (skipNewer)
+	{
+		list << "--update";
+	}
+	if (skipExisting)
+	{
+		list << "--ignore-existing";
+	}
+
+	if (compare)
+	{
+		switch (compareOption)
+		{
+		case Checksum:
+			list << "--checksum";
+			break;
+		case IgnoreSize:
+			list << "--ignore-size";
+			break;
+		case SizeOnly:
+			list << "--size-only";
+			break;
+		case ChecksumIgnoreSize:
+			list << "--checksum" << "--ignore-size";
+			break;
+		default: 
+			break;
+		}
+	}
+
+	if (verbose)
+	{
+		list << "--verbose";
+	}
+	if (sameFilesystem)
+	{
+		list << "--one-file-system";
+	}
+	if (dontUpdateModified)
+	{
+		list << "--no-update-modtime";
+	}
+
+	list << "--transfers" << transfers;
+	list << "--checkers" << checkers;
+
+	if (!bandwidth.isEmpty())
+	{
+		list << "--bwlimit" << bandwidth;
+	}
+	if (!minSize.isEmpty())
+	{
+		list << "--min-size" << minSize;
+	}
+	if (!minAge.isEmpty())
+	{
+		list << "--min-age" << minAge;
+	}
+	if (!maxAge.isEmpty())
+	{
+		list << "--max-age" << maxAge;
+	}
+
+	if (maxDepth != 0)
+	{
+		list << "--max-depth" << QString::number(maxDepth);
+	}
+
+	list << "--contimeout" << (connectTimeout + "s");
+	list << "--timeout" << (idleTimeout + "s");
+	list << "--retries" << retries;
+	list << "--low-level-retries" << lowLevelRetries;
+
+	if (deleteExcluded)
+	{
+		list << "--delete-excluded";
+	}
+
+	if (!excluded.isEmpty())
+	{
+		for (auto line : excluded.split('\n'))
+		{
+			list << "--exclude" << line;
+		}
+	}
+
+	if (!extra.isEmpty())
+	{
+		for (auto arg : extra.split(' '))
+		{
+			list << arg;
+		}
+	}
+
+	list << "--stats" << "1s";
+
+	list << source;
+	list << dest;
+
+	return list;
+}
+
+SerializationException::SerializationException(QString msg) : QException(), Message(msg)
+{
+}
+
+
+

--- a/src/JobOptions.h
+++ b/src/JobOptions.h
@@ -1,0 +1,107 @@
+#pragma once
+#include <qexception.h>
+#include <QListWidget>
+#include <quuid.h>
+
+class JobOptions 
+{
+public:
+	explicit JobOptions(bool isDownload);
+	JobOptions();
+
+	~JobOptions();
+
+	enum Operation { UnknownOp, Copy, Move, Sync };
+	enum JobType {UnknownJobType, Upload, Download};
+
+	/*
+	 * The following enums have their int values synchronized with the 
+	 * list indexes on the gui.  Changes needed to be synchronized.
+	 */
+	enum SyncTiming { During, After, Before, UnknownTiming};
+	enum CompareOption {SizeAndModTime, Checksum, IgnoreSize, SizeOnly, ChecksumIgnoreSize};
+
+	QString description;
+	
+	JobType jobType;
+	Operation operation;
+	bool dryRun;			// not persisted
+	bool sync;
+	SyncTiming syncTiming;
+	bool skipNewer;
+	bool skipExisting;
+	bool compare;
+	CompareOption compareOption;
+	bool verbose;
+	bool sameFilesystem;
+	bool dontUpdateModified;
+	QString transfers;
+	QString checkers;
+	QString bandwidth;
+	QString minSize;
+	QString minAge;
+	QString maxAge;
+	int maxDepth;
+	QString connectTimeout;
+	QString idleTimeout;
+	QString retries;
+	QString lowLevelRetries;
+	bool deleteExcluded;
+	QString excluded;
+	QString extra;
+	QString source;
+	QString dest;
+	bool isFolder;
+	QUuid uniqueId;
+
+
+	void setJobType (bool isDownload)
+	{
+		jobType = (isDownload) ? Download : Upload;
+	}
+
+	QString myName() const
+	{
+		return "JobOptions"; //this->staticQtMetaObject.myName();
+	}
+	QStringList getOptions() const;
+
+
+	bool operator==(const JobOptions &other) const 
+	{
+		return uniqueId == other.uniqueId;
+	}
+
+
+	/*
+	 * This allows the de-serialization method to accomodate changes
+	 * to the class structure, especially (most easily) added members.
+	 * 
+	 * Increment the value each time a change is made, emit the new field(s)
+	 * in the operator<< function, and in operator>> add conditional logic
+	 * based on the version for reading in the new field(s)
+	 */
+	static const qint32 classVersion;
+
+};
+
+class JobOptionsListWidgetItem : public QListWidgetItem
+{
+public:
+
+	JobOptionsListWidgetItem(JobOptions *jo, const QIcon &icon, const QString &text) : QListWidgetItem(icon, text),  mJobData(jo) {}
+
+	void SetData(JobOptions *jo) { mJobData = jo; }
+	JobOptions *GetData() { return mJobData; }
+
+private:
+	JobOptions *mJobData;
+};
+
+class SerializationException : public QException
+{
+public:
+	QString Message;
+	explicit SerializationException(QString msg);
+};
+

--- a/src/ListOfJobOptions.cpp
+++ b/src/ListOfJobOptions.cpp
@@ -1,0 +1,202 @@
+#include "ListOfJobOptions.h"
+#include <QDataStream>
+#include <qstandardpaths.h>
+#include <qdir.h>
+#include <qdebug.h>
+#include <qlogging.h>
+
+static QDataStream& operator >> (QDataStream& dataStream, JobOptions& jo);
+static QDataStream& operator << (QDataStream& dataStream, JobOptions& jo);
+static QDataStream& operator >> (QDataStream& in, JobOptions::Operation& e);
+static QDataStream& operator >> (QDataStream& in, JobOptions::SyncTiming& e);
+static QDataStream& operator >> (QDataStream& in, JobOptions::CompareOption& e);
+static QDataStream& operator >> (QDataStream& in, JobOptions::JobType& e);
+
+ListOfJobOptions* ListOfJobOptions::SavedJobOptions = nullptr;
+const QString ListOfJobOptions::persistenceFileName = "tasks.bin";
+
+
+ListOfJobOptions::ListOfJobOptions()
+{
+}
+
+ListOfJobOptions* ListOfJobOptions::getInstance()
+{
+	if (SavedJobOptions == nullptr)
+	{
+		SavedJobOptions = new ListOfJobOptions();
+		RestoreFromUserData(*SavedJobOptions);
+	}
+	return SavedJobOptions;
+}
+
+bool ListOfJobOptions::Persist(JobOptions* jo)
+{
+	bool isNew = !this->tasks.contains(jo);
+	if (isNew)
+		this->tasks.append(jo);
+	else
+	{
+		int ix = tasks.indexOf(jo);
+		JobOptions *old = tasks[ix];
+		qDebug() << QString("old [%1] New [%2]").arg(old->description).arg(jo->description);
+	}
+	PersistToUserData();
+	return isNew;
+}
+
+bool ListOfJobOptions::Forget(JobOptions* jo)
+{
+	bool isKnown = this->tasks.contains(jo);
+	if (!isKnown)
+		return false;
+	int ix = tasks.indexOf(jo);
+	tasks.removeAt(ix);
+	qDebug() << QString("removed [%1]").arg(jo->description);
+	PersistToUserData();
+	return isKnown;
+}
+
+QFile* ListOfJobOptions::GetPersistenceFile(QIODevice::OpenModeFlag mode)
+{
+	QDir outputDir(QStandardPaths::writableLocation(QStandardPaths::DataLocation));
+	if (!outputDir.exists())
+	{
+		outputDir.mkpath(".");
+	}
+	QString filePath = outputDir.absoluteFilePath(persistenceFileName);
+	QFile* file = new QFile(filePath);
+	if (!file->open(mode))
+	{
+		qDebug() << QString("Could not open ") << file->fileName();
+		delete file;
+		file = nullptr;
+	}
+	return file;
+}
+
+bool ListOfJobOptions::RestoreFromUserData(ListOfJobOptions& dataIn)
+{
+	QFile* file = GetPersistenceFile(QIODevice::ReadOnly);
+	if (file == nullptr) return false;
+	QDataStream instream(file);
+	instream.setVersion(QDataStream::Qt_5_2);
+
+	while (!instream.atEnd())
+	{
+		try
+		{
+			JobOptions *jo = new JobOptions();
+			instream >> *jo;
+			dataIn.tasks.append(jo);
+		}
+		catch (SerializationException ex)
+		{
+			qDebug() << QString("failed to restore tasks: ") << ex.Message;
+			file->close();
+			delete file;
+			return false;
+		}
+	}
+
+	file->close();
+	delete file;
+
+	return true;
+}
+
+bool ListOfJobOptions::PersistToUserData()
+{
+	QFile* file = GetPersistenceFile(QIODevice::WriteOnly); // note this mode implies Truncate also
+	if (file == nullptr) return false;
+	QDataStream outstream(file);
+	outstream.setVersion(QDataStream::Qt_5_2);
+
+	for (JobOptions *it : tasks )
+	{
+		outstream << *it;
+	}
+
+	file->flush();
+	file->close();
+
+	emit tasksListUpdated();
+
+	delete file;
+
+	return true;
+}
+
+QDataStream& operator<<(QDataStream& stream, JobOptions& jo)
+{
+	stream << jo.myName() << JobOptions::classVersion << jo.description
+		<< jo.jobType << jo.operation << /* jo.dryRun <<*/ jo.sync << jo.syncTiming
+		<< jo.skipNewer << jo.skipExisting << jo.compare << jo.compareOption
+		<< jo.verbose << jo.sameFilesystem << jo.dontUpdateModified << jo.transfers
+		<< jo.checkers << jo.bandwidth << jo.minSize << jo.minAge << jo.maxAge
+		<< jo.maxDepth << jo.connectTimeout << jo.idleTimeout << jo.retries
+		<< jo.lowLevelRetries << jo.deleteExcluded << jo.excluded << jo.extra
+		<< jo.source << jo.dest << jo.isFolder << jo.uniqueId;
+
+	return stream;
+}
+
+QDataStream& operator >> (QDataStream& stream, JobOptions& jo)
+{
+	QString actualName;
+	qint32 actualVersion;
+
+	stream >> actualName;
+	if (QString::compare(actualName, jo.myName()) != 0)
+		throw SerializationException("incorrect class");
+
+	stream >> actualVersion;
+	if (actualVersion > JobOptions::classVersion)
+		throw SerializationException("stored version is newer");
+
+	stream >> jo.description
+		>> jo.jobType >> jo.operation >> /* jo.dryRun >> */ jo.sync >> jo.syncTiming
+		>> jo.skipNewer >> jo.skipExisting >> jo.compare >> jo.compareOption
+		>> jo.verbose >> jo.sameFilesystem >> jo.dontUpdateModified >> jo.transfers
+		>> jo.checkers >> jo.bandwidth >> jo.minSize >> jo.minAge >> jo.maxAge
+		>> jo.maxDepth >> jo.connectTimeout >> jo.idleTimeout >> jo.retries
+		>> jo.lowLevelRetries >> jo.deleteExcluded >> jo.excluded >> jo.extra
+		>> jo.source >> jo.dest;
+
+	// as fields are added in later revisions, check actualVersion here and 
+	// conditionally extract any new fields iff they are expected based on the stream value
+	if (actualVersion >= 2)
+	{
+		stream >> jo.isFolder;
+		if (actualVersion >= 3)
+		{
+			stream >> jo.uniqueId;
+		}
+	}
+
+	return stream;
+}
+
+QDataStream& operator >> (QDataStream& in, JobOptions::Operation& e)
+{
+	in >> (quint32&)e;
+	return in;
+}
+
+QDataStream& operator >> (QDataStream& in, JobOptions::SyncTiming& e)
+{
+	in >> (quint32&)e;
+	return in;
+}
+
+QDataStream& operator >> (QDataStream& in, JobOptions::CompareOption& e)
+{
+	in >> (quint32&)e;
+	return in;
+}
+
+QDataStream& operator >> (QDataStream& in, JobOptions::JobType& e)
+{
+	in >> (quint32&)e;
+	return in;
+}

--- a/src/ListOfJobOptions.h
+++ b/src/ListOfJobOptions.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <qfile.h>
+#include "JobOptions.h"
+
+class ListOfJobOptions : public QObject
+{
+	Q_OBJECT
+
+protected:
+	~ListOfJobOptions() = default;
+	ListOfJobOptions();
+public:
+	static ListOfJobOptions* getInstance();
+	bool Persist(JobOptions *jo);
+	bool Forget(JobOptions *jo);
+	QList<JobOptions*> &getTasks() { return tasks; }
+
+signals: 
+	void tasksListUpdated();
+
+private:
+	static ListOfJobOptions* SavedJobOptions;
+	static const QString persistenceFileName;
+	static bool RestoreFromUserData(ListOfJobOptions& dataIn);
+	static QFile* GetPersistenceFile(QIODevice::OpenModeFlag mode);
+
+
+	QList<JobOptions*> tasks;
+	bool PersistToUserData();
+
+};
+

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "ui_main_window.h"
 #include "icon_cache.h"
+#include "JobOptions.h"
 
 class JobWidget;
 
@@ -18,6 +19,7 @@ private slots:
     void rcloneGetVersion();
     void rcloneConfig();
     void rcloneListRemotes();
+    void listTasks();
 
     void addTransfer(const QString& message, const QString& source, const QString& dest, const QStringList& args);
     void addMount(const QString& remote, const QString& folder);
@@ -42,7 +44,12 @@ private:
 
     bool canClose();
     void closeEvent(QCloseEvent* ev) override;
-    bool getConfigPassword(QProcess* p);
+	bool getConfigPassword(QProcess* p);
 
     void addEmptyJobsMessage();
+
+	void runItem(JobOptionsListWidgetItem* item, bool dryrun = false);
+	void editSelectedTask();
+	QIcon mUploadIcon;
+	QIcon mDownloadIcon;
 };

--- a/src/main_window.ui
+++ b/src/main_window.ui
@@ -14,7 +14,7 @@
    <string>Rclone Browser</string>
   </property>
   <widget class="QWidget" name="widgetMain">
-   <layout class="QVBoxLayout" name="layoutMain">
+   <layout class="QVBoxLayout" name="verticalLayout_3">
     <property name="spacing">
      <number>0</number>
     </property>
@@ -33,7 +33,7 @@
     <item>
      <widget class="QTabWidget" name="tabs">
       <property name="currentIndex">
-       <number>0</number>
+       <number>2</number>
       </property>
       <property name="tabsClosable">
        <bool>true</bool>
@@ -117,8 +117,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>628</width>
-             <height>305</height>
+             <width>624</width>
+             <height>285</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -164,6 +164,189 @@
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="tasksTab">
+       <attribute name="title">
+        <string>Tasks</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_5">
+        <property name="leftMargin">
+         <number>4</number>
+        </property>
+        <property name="topMargin">
+         <number>4</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QScrollArea" name="tasksArea">
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollAreaWidgetContentsTasks">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>646</width>
+             <height>307</height>
+            </rect>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_6">
+            <item>
+             <widget class="QListWidget" name="tasksListWidget"/>
+            </item>
+            <item>
+             <layout class="QVBoxLayout" name="tasks" stretch=""/>
+            </item>
+            <item>
+             <widget class="QWidget" name="tasksActionBar" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>20</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>32</height>
+               </size>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_2">
+               <property name="spacing">
+                <number>4</number>
+               </property>
+               <property name="leftMargin">
+                <number>4</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>4</number>
+               </property>
+               <property name="bottomMargin">
+                <number>4</number>
+               </property>
+               <item>
+                <widget class="QPushButton" name="buttonDryrunTask">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>28</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>-&gt; Dry Run</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="buttonRunTask">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>28</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Run</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="buttonEditTask">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>28</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>100</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="layoutDirection">
+                  <enum>Qt::LeftToRight</enum>
+                 </property>
+                 <property name="text">
+                  <string>Edit</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="buttonDeleteTask">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>28</height>
+                  </size>
+                 </property>
+                 <property name="layoutDirection">
+                  <enum>Qt::LeftToRight</enum>
+                 </property>
+                 <property name="text">
+                  <string>Delete</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </item>
    </layout>
@@ -174,7 +357,7 @@
      <x>0</x>
      <y>0</y>
      <width>658</width>
-     <height>22</height>
+     <height>31</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/src/remote_widget.cpp
+++ b/src/remote_widget.cpp
@@ -5,6 +5,7 @@
 #include "icon_cache.h"
 #include "item_model.h"
 #include "utils.h"
+#include "ListOfJobOptions.h"
 
 RemoteWidget::RemoteWidget(IconCache* iconCache, const QString& remote, bool isLocal, QWidget* parent)
     : QWidget(parent)

--- a/src/transfer_dialog.cpp
+++ b/src/transfer_dialog.cpp
@@ -1,9 +1,10 @@
 #include "transfer_dialog.h"
 #include "utils.h"
+#include "ListOfJobOptions.h"
 
-TransferDialog::TransferDialog(bool isDownload, const QString& remote, const QDir& path, bool isFolder, QWidget* parent)
+TransferDialog::TransferDialog(bool isDownload, const QString& remote, const QDir& path, bool isFolder, QWidget* parent, JobOptions *task, bool editMode)
     : QDialog(parent)
-    , mIsDownload(isDownload)
+    , mIsDownload(isDownload), mIsFolder(isFolder), mIsEditMode(editMode), mJobOptions(task)
 {
     ui.setupUi(this);
     resize(0, 0);
@@ -14,10 +15,19 @@ TransferDialog::TransferDialog(bool isDownload, const QString& remote, const QDi
     ui.buttonSourceFolder->setIcon(style->standardIcon(QStyle::SP_DirIcon));
     ui.buttonDest->setIcon(style->standardIcon(QStyle::SP_DirIcon));
 
-    QPushButton* dryRun = ui.buttonBox->addButton("&Dry run", QDialogButtonBox::AcceptRole);
-    ui.buttonBox->addButton("&Run", QDialogButtonBox::AcceptRole);
+	if (!mIsEditMode)
+	{
+		QPushButton* dryRun = ui.buttonBox->addButton("&Dry run", QDialogButtonBox::AcceptRole);
+		ui.buttonBox->addButton("&Run", QDialogButtonBox::AcceptRole);
+		QObject::connect(dryRun, &QPushButton::clicked, this, [=]()
+		{
+			mDryRun = true;
+		});
+	}
 
-    QObject::connect(ui.buttonBox->button(QDialogButtonBox::RestoreDefaults), &QPushButton::clicked, this, [=]()
+	QPushButton* saveTask = ui.buttonBox->addButton("&Save task", QDialogButtonBox::ButtonRole::ActionRole);
+
+	QObject::connect(ui.buttonBox->button(QDialogButtonBox::RestoreDefaults), &QPushButton::clicked, this, [=]()
     {
         ui.cbSyncDelete->setCurrentIndex(0);
         ui.checkSkipNewer->setChecked(false);
@@ -44,10 +54,28 @@ TransferDialog::TransferDialog(bool isDownload, const QString& remote, const QDi
     });
     ui.buttonBox->button(QDialogButtonBox::RestoreDefaults)->click();
 
-    QObject::connect(dryRun, &QPushButton::clicked, this, [=]()
-    {
-        mDryRun = true;
-    });
+	QObject::connect(saveTask, &QPushButton::clicked, this, [=]()
+	{
+		// validate before saving task...
+		if (ui.textDescription->text().isEmpty())
+		{
+			QMessageBox::warning(this, "Warning", "Please enter task description to Save!");
+			ui.textDescription->setFocus(Qt::FocusReason::OtherFocusReason);
+			return;
+		}
+		// even though the below does not match the condition on the Run buttons
+		// it SEEMS like blanking either one would be a problem, right?
+		if (ui.textDest->text().isEmpty() || ui.textSource->text().isEmpty())
+		{
+			QMessageBox::warning(this, "Error", "Invalid Task, source and destination required!");
+			return;
+		}
+		JobOptions* jobo = getJobOptions();
+		ListOfJobOptions::getInstance()->Persist(jobo);
+		if (mIsEditMode)
+			this->close();
+	});
+
     QObject::connect(ui.buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
     QObject::connect(ui.buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
@@ -95,7 +123,26 @@ TransferDialog::TransferDialog(bool isDownload, const QString& remote, const QDi
     ui.buttonSourceFolder->setVisible(!isDownload);
     ui.buttonDest->setVisible(isDownload);
 
-    (isDownload ? ui.textSource : ui.textDest)->setText(remote + ":" + path.path());
+	if (mIsEditMode && mJobOptions != nullptr)
+	{
+		// it's not really valid for only one of these things to be true.
+		// when operating on an existing instance i.e. a saved task, 
+		// changing the dest or src seems to have problems so we
+		// will not allow it.  simple enough, and better, to make a 
+		// new task for different pairings anyway.  that will make 
+		// a lot more sense when/if scheduling and history are added...
+		ui.buttonSourceFile->setVisible(false);
+		ui.buttonSourceFolder->setVisible(false);
+		ui.buttonDest->setVisible(false);
+		ui.textDest->setDisabled(true);
+		ui.textSource->setDisabled(true);		
+		putJobOptions();
+	} 
+	else
+	{
+		(isDownload ? ui.textSource : ui.textDest)->setText(remote + ":" + path.path());		
+	}
+
 }
 
 TransferDialog::~TransferDialog()
@@ -144,140 +191,162 @@ QString TransferDialog::getDest() const
     return ui.textDest->text();
 }
 
-QStringList TransferDialog::getOptions() const
+QStringList TransferDialog::getOptions()
 {
-    QString mode;
+	JobOptions* jobo = getJobOptions();
+	QStringList newWay = jobo->getOptions();
+	return newWay;
+}
 
-    QStringList list;
-    if (ui.rbCopy->isChecked())
-    {
-        list << "copy";
-        mode = "Copy";
-    }
-    else if (ui.rbMove->isChecked())
-    {
-        list << "move";
-        mode = "Move";
-    }
-    else if (ui.rbSync->isChecked())
-    {
-        list << "sync";
-        mode = "Sync";
-    }
+/*
+ * Apply the displayed/edited values on the UI to the 
+ * JobOptions object.  
+ * 
+ * This needs to be edited whenever options are added or changed.
+ */
+JobOptions *TransferDialog::getJobOptions()
+{
+	if (mJobOptions == nullptr)
+		mJobOptions = new JobOptions(mIsDownload);
 
-    if (mDryRun)
-    {
-        list << "--dry-run";
-    }
-    if (ui.rbSync->isChecked())
-    {
-        switch (ui.cbSyncDelete->currentIndex())
-        {
-        case 0:
-            list << "--delete-during";
-            break;
-        case 1:
-            list << "--delete-after";
-            break;
-        case 2:
-            list << "--delete-before";
-            break;
-        }
-    }
-    if (ui.checkSkipNewer->isChecked())
-    {
-        list << "--update";
-    }
-    if (ui.checkSkipExisting->isChecked())
-    {
-        list << "--ignore-existing";
-    }
-    if (ui.checkCompare->isChecked())
-    {
-        switch (ui.cbCompare->currentIndex())
-        {
-        case 1:
-            list << "--checksum";
-            break;
-        case 2:
-            list << "--ignore-size";
-            break;
-        case 3:
-            list << "--size-only";
-            break;
-        case 4:
-            list << "--checksum" << "--ignore-size";
-            break;
-        }
-    }
-    if (ui.checkVerbose->isChecked())
-    {
-        list << "--verbose";
-    }
-    if (ui.checkSameFilesystem->isChecked())
-    {
-        list << "--one-file-system";
-    }
-    if (ui.checkDontUpdateModified->isChecked())
-    {
-        list << "--no-update-modtime";
-    }
-    list << "--transfers" << ui.spinTransfers->text();
-    list << "--checkers" << ui.spinCheckers->text();
-    if (!ui.textBandwidth->text().isEmpty())
-    {
-        list << "--bwlimit" << ui.textBandwidth->text();
-    }
-    if (!ui.textMinSize->text().isEmpty())
-    {
-        list << "--min-size" << ui.textMinSize->text();
-    }
-    if (!ui.textMinAge->text().isEmpty())
-    {
-        list << "--min-age" << ui.textMinAge->text();
-    }
-    if (!ui.textMaxAge->text().isEmpty())
-    {
-        list << "--max-age" << ui.textMaxAge->text();
-    }
-    if (ui.spinMaxDepth->value() != 0)
-    {
-        list << "--max-depth" << ui.spinMaxDepth->text();
-    }
-    list << "--contimeout" << (ui.spinConnectTimeout->text() + "s");
-    list << "--timeout" << (ui.spinIdleTimeout->text() + "s");
-    list << "--retries" << ui.spinRetries->text();
-    list << "--low-level-retries" << ui.spinLowLevelRetries->text();
+	if (ui.rbCopy->isChecked())
+	{
+		mJobOptions->operation = JobOptions::Copy;
+	}
+	else if (ui.rbMove->isChecked())
+	{
+		mJobOptions->operation = JobOptions::Move;
+	}
+	else if (ui.rbSync->isChecked())
+	{
+		mJobOptions->operation = JobOptions::Sync;
+	}
 
-    if (ui.checkDeleteExcluded->isChecked())
-    {
-        list << "--delete-excluded";
-    }
+	mJobOptions->dryRun = mDryRun;;
 
-    QString excluded = ui.textExclude->toPlainText().trimmed();
-    if (!excluded.isEmpty())
-    {
-        for (auto line : excluded.split('\n'))
-        {
-            list << "--exclude" << line;
-        }
-    }
+	if (ui.rbSync->isChecked())
+	{
+		mJobOptions->sync = true;
+		switch (ui.cbSyncDelete->currentIndex())
+		{
+		case 0:
+			mJobOptions->syncTiming = JobOptions::During;
+			break;
+		case 1:
+			mJobOptions->syncTiming = JobOptions::After;
+			break;
+		case 2:
+			mJobOptions->syncTiming = JobOptions::Before;
+			break;
+		}
+	}
 
-    QString extra = ui.textExtra->text().trimmed();
-    if (!extra.isEmpty())
-    {
-        for (auto arg : extra.split(' '))
-        {
-            list << arg;
-        }
-    }
+	mJobOptions->skipNewer = ui.checkSkipNewer->isChecked();
+	mJobOptions->skipExisting = ui.checkSkipExisting->isChecked();
 
-    list << "--stats" << "1s";
+	if (ui.checkCompare->isChecked())
+	{
+		mJobOptions->compare = true;
+		switch (ui.cbCompare->currentIndex())
+		{
+		case 0:
+			mJobOptions->compareOption = JobOptions::SizeAndModTime;
+			break;
+		case 1:
+			mJobOptions->compareOption = JobOptions::Checksum;
+			break;
+		case 2:
+			mJobOptions->compareOption = JobOptions::IgnoreSize;
+			break;
+		case 3:
+			mJobOptions->compareOption = JobOptions::SizeOnly;
+			break;
+		case 4:
+			mJobOptions->compareOption = JobOptions::ChecksumIgnoreSize;
+			break;
+		}
+	}
 
-    list << ui.textSource->text();
-    list << ui.textDest->text();
+	mJobOptions->verbose = ui.checkVerbose->isChecked();
+	mJobOptions->sameFilesystem = ui.checkSameFilesystem->isChecked();
+	mJobOptions->dontUpdateModified = ui.checkDontUpdateModified->isChecked();
 
-    return list;
+	mJobOptions->transfers = ui.spinTransfers->text();
+	mJobOptions->checkers = ui.spinCheckers->text();
+	mJobOptions->bandwidth = ui.textBandwidth->text();
+	mJobOptions->minSize =  ui.textMinSize->text();
+	mJobOptions->minAge = ui.textMinAge->text();
+	mJobOptions->maxAge = ui.textMaxAge->text();
+	mJobOptions->maxDepth = ui.spinMaxDepth->value();
+
+	mJobOptions->connectTimeout = ui.spinConnectTimeout->text();
+	mJobOptions->idleTimeout = ui.spinIdleTimeout->text();
+	mJobOptions->retries = ui.spinRetries->text();
+	mJobOptions->lowLevelRetries = ui.spinLowLevelRetries->text();
+	mJobOptions->deleteExcluded = ui.checkDeleteExcluded->isChecked();
+
+	mJobOptions->excluded = ui.textExclude->toPlainText().trimmed();
+	mJobOptions->extra = ui.textExtra->text().trimmed();
+
+	mJobOptions->source = ui.textSource->text();
+	mJobOptions->dest = ui.textDest->text();
+	mJobOptions->isFolder = mIsFolder;
+
+	mJobOptions->description = ui.textDescription->text();
+	
+	return mJobOptions;
+}
+
+/*
+ * Apply the JobOptions object to the displayed widget values.
+ * 
+ * It could be "better" to use a two-way binding mechanism, but 
+ * if used that should be global to the app; and anyway doing 
+ * it this old primitive way makes it easier when the user wants 
+ * to not save changes...
+ */
+void TransferDialog::putJobOptions()
+{
+	ui.rbCopy->setChecked(mJobOptions->operation == JobOptions::Copy);
+	ui.rbMove->setChecked(mJobOptions->operation == JobOptions::Move);
+	ui.rbSync->setChecked(mJobOptions->operation == JobOptions::Sync);
+
+	mDryRun = mJobOptions->dryRun;
+	ui.rbSync->setChecked(mJobOptions->sync);
+	ui.cbSyncDelete->setCurrentIndex((int)mJobOptions->syncTiming);
+
+
+	ui.checkSkipNewer->setChecked(mJobOptions->skipNewer);
+	ui.checkSkipExisting->setChecked(mJobOptions->skipExisting);
+
+	ui.checkCompare->setChecked(mJobOptions->compare);
+	ui.cbCompare->setCurrentIndex(mJobOptions->compareOption);
+
+	ui.checkVerbose->setChecked(mJobOptions->verbose);
+	ui.checkSameFilesystem->setChecked(mJobOptions->sameFilesystem);
+	ui.checkDontUpdateModified->setChecked(mJobOptions->dontUpdateModified);
+
+	ui.spinTransfers->setValue(mJobOptions->transfers.toInt());
+	ui.spinCheckers->setValue(mJobOptions->checkers.toInt());
+	ui.textBandwidth->setText(mJobOptions->bandwidth);
+	ui.textMinSize->setText(mJobOptions->minSize);
+	ui.textMinAge->setText(mJobOptions->minAge);
+	ui.textMaxAge->setText(mJobOptions->maxAge);
+	ui.spinMaxDepth->setValue(mJobOptions->maxDepth);
+
+	ui.spinConnectTimeout->setValue(mJobOptions->connectTimeout.toInt());
+	ui.spinIdleTimeout->setValue(mJobOptions->idleTimeout.toInt());
+	ui.spinRetries->setValue(mJobOptions->retries.toInt());
+	ui.spinLowLevelRetries->setValue(mJobOptions->lowLevelRetries.toInt());
+	ui.checkDeleteExcluded->setChecked(mJobOptions->deleteExcluded);
+
+	ui.textExclude->setPlainText(mJobOptions->excluded);
+	ui.textExtra->setText(mJobOptions->extra);
+
+	ui.textSource->setText(mJobOptions->source);
+	ui.textDest->setText(mJobOptions->dest);
+
+	ui.textDescription->setText(mJobOptions->description);
 }
 
 void TransferDialog::done(int r)

--- a/src/transfer_dialog.h
+++ b/src/transfer_dialog.h
@@ -2,13 +2,14 @@
 
 #include "pch.h"
 #include "ui_transfer_dialog.h"
+#include "JobOptions.h"
 
 class TransferDialog : public QDialog
 {
     Q_OBJECT
 
 public:
-    TransferDialog(bool isDownload, const QString& remote, const QDir& path, bool isFolder, QWidget* parent = nullptr);
+    TransferDialog(bool isDownload, const QString& remote, const QDir& path, bool isFolder, QWidget* parent = nullptr, JobOptions *task = nullptr, bool editMode = false);
     ~TransferDialog();
 
     void setSource(const QString& path);
@@ -16,13 +17,24 @@ public:
     QString getMode() const;
     QString getSource() const;
     QString getDest() const;
-    QStringList getOptions() const;
+    QStringList getOptions();
+
+	JobOptions *getJobOptions();
 
 private:
     Ui::TransferDialog ui;
 
     bool mIsDownload;
     bool mDryRun = false;
+	bool mIsFolder;
+	bool mIsEditMode;
+
+	JobOptions *mJobOptions;
+
+	void putJobOptions();
 
     void done(int r) override;
+
+signals:
+	void tasksListChanged();
 };

--- a/src/transfer_dialog.ui
+++ b/src/transfer_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>756</width>
-    <height>587</height>
+    <width>765</width>
+    <height>664</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -372,6 +372,16 @@
           <item>
            <widget class="QLineEdit" name="textExtra"/>
           </item>
+          <item>
+           <widget class="QLabel" name="label_15">
+            <property name="text">
+             <string>Task description</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="textDescription"/>
+          </item>
          </layout>
         </widget>
        </item>
@@ -722,7 +732,6 @@
   <tabstop>checkVerbose</tabstop>
   <tabstop>checkSameFilesystem</tabstop>
   <tabstop>checkDontUpdateModified</tabstop>
-  <tabstop>textExtra</tabstop>
   <tabstop>spinTransfers</tabstop>
   <tabstop>spinCheckers</tabstop>
   <tabstop>textBandwidth</tabstop>


### PR DESCRIPTION
I really like RcloneBrowser and found it immediately useful.  The big thing that I wanted right away that it doesn't have is, the ability to easily repeat a task so that I can keep the remotes up to date, with a smattering of local folders that I want to back up but that are scattered around in different local drives, and without needing to recreate the job each time.  So... in this substantial mod I have added the ability to save any set of upload or download job options as a "task", persisting those to app local storage and automatically loading them back in at startup time, with a new permanent Tasks tab on the main window to view, edit, delete, dry-run or run them.  

I've done the dev work on Windows, VS 2015 with the 2013 toolset selected, but I also built and lightly tested on Debian; and only with Amazon Drive as a target.  Sorry, no Mac testing, I haven't powered on my one little Mac in about 5 years and think it would be a great struggle to get to the point of trying to build there.

I'm still a bit lost with the git process and I hope I am not making a mess.  This work required some trial-and-try-again to get right and in that mode I make a lot of little commits locally; I understand that it is "possible" to compress them into one but I did not try that... I could if the sequence of little steps seems unappealing as such...

Anyway, I'd like to suggest you consider adopting this mod.  I certainly find it useful, and I think it's a big step toward a possible second stretch to add scheduling and history.

Let me know what you think... the only thing left on *my* todo list was to rework the list on the Tasks tab to use a Table... right now it only shows an up or down icon and description, I didn't appreciate how limiting it would be to start out with a list widget I supposed I would be able to format the items with further elements from the task such as source and dest.  

best regards, 

/tom
