### PR TITLE
fix config button did not work when path of rclone.conf was specified

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -143,7 +143,7 @@ QStringList GetRcloneConf()
     {
         conf = QDir(qApp->applicationDirPath()).filePath(conf);
     }
-    return QStringList() << "--config" << conf;
+    return QStringList() << " --config" << conf;
 }
 
 void SetRcloneConf(const QString& rcloneConf)


### PR DESCRIPTION
`/tmp/rclone_config.command ; exit;`

```
Error: unknown command "config--config" for "rclone"
Run 'rclone --help' for usage.
Fatal error: unknown command "config--config" for "rclone"
```
File `/tmp/rclone_config.command`
```
#!/bin/sh
/usr/local/bin/rclone config--config /path/to/conf
```